### PR TITLE
Remove Unnecessary Error Alert for Fetching Coins

### DIFF
--- a/CryptoChallenge/ContentView.swift
+++ b/CryptoChallenge/ContentView.swift
@@ -127,15 +127,7 @@ struct ContentView: View {
                 
                 
             }
-            .alert(isPresented: .constant(viewModel.errorMessage != nil)) {
-                Alert(
-                    title: Text("Error"),
-                    message: Text(viewModel.errorMessage ?? ""),
-                    dismissButton: .default(Text("OK")) {
-                        viewModel.errorMessage = nil
-                    }
-                )
-            }
+
             
         }
         .onAppear{

--- a/CryptoChallenge/ViewModels/CoinListViewModel.swift
+++ b/CryptoChallenge/ViewModels/CoinListViewModel.swift
@@ -12,7 +12,6 @@ import SwiftData
 class CoinListViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var isLoading: Bool = false
-    @Published var errorMessage: String? = nil
     @Published var lastUpdated: Date? = nil
 
     var context: ModelContext
@@ -39,14 +38,13 @@ class CoinListViewModel: ObservableObject {
 
     func fetchCoins() async {
         isLoading = true
-        errorMessage = nil
         do {
             let fetchedCoins = try await coinService.fetchCoins()
             // Update local store with the latest
             persistCoinsToSwiftData(fetchedCoins)
             lastUpdated = Date()
         } catch {
-            errorMessage = "Error fetching coins: \(error.localizedDescription)"
+            print("Couldn't fetch fetching coins: \(error.localizedDescription)")
         }
         isLoading = false
     }


### PR DESCRIPTION
Removed the alert for errors when fetching coins. Since local persistence is in place, and the UI already indicates when there is no internet connection, the alert was redundant and unnecessary. This streamlines the user experience.