### PR TITLE
Development Final Fixes

### DIFF
--- a/CryptoChallenge/ContentView.swift
+++ b/CryptoChallenge/ContentView.swift
@@ -127,15 +127,7 @@ struct ContentView: View {
                 
                 
             }
-            .alert(isPresented: .constant(viewModel.errorMessage != nil)) {
-                Alert(
-                    title: Text("Error"),
-                    message: Text(viewModel.errorMessage ?? ""),
-                    dismissButton: .default(Text("OK")) {
-                        viewModel.errorMessage = nil
-                    }
-                )
-            }
+
             
         }
         .onAppear{

--- a/CryptoChallenge/ViewModels/CoinListViewModel.swift
+++ b/CryptoChallenge/ViewModels/CoinListViewModel.swift
@@ -12,7 +12,6 @@ import SwiftData
 class CoinListViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var isLoading: Bool = false
-    @Published var errorMessage: String? = nil
     @Published var lastUpdated: Date? = nil
 
     var context: ModelContext
@@ -39,14 +38,13 @@ class CoinListViewModel: ObservableObject {
 
     func fetchCoins() async {
         isLoading = true
-        errorMessage = nil
         do {
             let fetchedCoins = try await coinService.fetchCoins()
             // Update local store with the latest
             persistCoinsToSwiftData(fetchedCoins)
             lastUpdated = Date()
         } catch {
-            errorMessage = "Error fetching coins: \(error.localizedDescription)"
+            print("Couldn't fetch fetching coins: \(error.localizedDescription)")
         }
         isLoading = false
     }


### PR DESCRIPTION
*This pull request removes the redundant error alert for coin-fetching failures. The UI already provides a clear indication of network issues, and local persistence ensures data is still accessible offline, making the alert unnecessary*